### PR TITLE
feat : 감상문에 Diffutil 적용

### DIFF
--- a/app/src/main/kotlin/com/teamfilmo/filmo/ui/body/BodyMovieReportFragment.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/ui/body/BodyMovieReportFragment.kt
@@ -12,7 +12,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.bumptech.glide.Glide
-import com.teamfilmo.filmo.R
 import com.teamfilmo.filmo.base.fragment.BaseFragment
 import com.teamfilmo.filmo.databinding.FragmentBodyMovieReportBinding
 import com.teamfilmo.filmo.ui.widget.ModalBottomSheet
@@ -147,7 +146,8 @@ class BodyMovieReportFragment : BaseFragment<FragmentBodyMovieReportBinding, Bod
             is BodyMovieReportEffect.DeleteReport -> {
                 // 전체 감상문 리스트에서 삭제 완료되었다는 토스트 메시지 +ㄴ 토스트 띄우기
                 Toast.makeText(context, "감상문을 삭제했어요!", Toast.LENGTH_SHORT).show()
-                navController.navigate(R.id.allMovieReportFragment)
+                navController.popBackStack()
+                //    navController.navigate(R.id.allMovieReportFragment)
             }
             is BodyMovieReportEffect.ShowMovieContent -> {
                 lifecycleScope.launch {

--- a/app/src/main/kotlin/com/teamfilmo/filmo/ui/mypage/MyPageFragment.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/ui/mypage/MyPageFragment.kt
@@ -64,7 +64,6 @@ class MyPageFragment : BaseFragment<FragmentMyPageBinding, MyPageViewModel, MyPa
                     binding.txtCountFollowing.text = it.toString()
                 }
             }
-
         }
     }
 

--- a/app/src/main/kotlin/com/teamfilmo/filmo/ui/report/ReportDiffCallback.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/ui/report/ReportDiffCallback.kt
@@ -1,0 +1,27 @@
+package com.teamfilmo.filmo.ui.report
+
+import androidx.recyclerview.widget.DiffUtil
+import com.teamfilmo.filmo.data.remote.model.report.all.ReportItem
+
+class ReportDiffCallback(
+    private val oldList: List<ReportItem>,
+    private val newList: List<ReportItem>,
+) : DiffUtil.Callback() {
+    override fun getOldListSize(): Int = oldList.size
+
+    override fun getNewListSize(): Int = newList.size
+
+    override fun areItemsTheSame(
+        oldItemPosition: Int,
+        newItemPosition: Int,
+    ): Boolean {
+        return oldList[oldItemPosition].reportId == newList[newItemPosition].reportId
+    }
+
+    override fun areContentsTheSame(
+        oldItemPosition: Int,
+        newItemPosition: Int,
+    ): Boolean {
+        return oldList[oldItemPosition] == newList[newItemPosition]
+    }
+}

--- a/app/src/main/kotlin/com/teamfilmo/filmo/ui/report/adapter/AllMovieReportAdapter.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/ui/report/adapter/AllMovieReportAdapter.kt
@@ -2,11 +2,13 @@ package com.teamfilmo.filmo.ui.report.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.teamfilmo.filmo.R
 import com.teamfilmo.filmo.data.remote.model.report.all.ReportItem
 import com.teamfilmo.filmo.databinding.MovieItemBinding
+import com.teamfilmo.filmo.ui.report.ReportDiffCallback
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -72,12 +74,15 @@ class AllMovieReportAdapter : RecyclerView.Adapter<AllMovieReportAdapter.AllMovi
     fun setReportInfo(
         newReportList: List<ReportItem>,
     ) {
-        val list = newReportList
-        val currentSize = reportList.size
+        val diffCallback = ReportDiffCallback(reportList, newReportList)
+        val diffResult = DiffUtil.calculateDiff(diffCallback)
+//        val list = newReportList
+//        val currentSize = reportList.size
         reportList.clear()
-        reportList.addAll(list)
-        notifyItemRangeRemoved(0, currentSize)
-        notifyItemRangeInserted(0, reportList.size)
+        reportList.addAll(newReportList)
+        diffResult.dispatchUpdatesTo(this)
+//        notifyItemRangeRemoved(0, currentSize)
+//        notifyItemRangeInserted(0, reportList.size)
     }
 
     override fun onCreateViewHolder(


### PR DESCRIPTION
### 구현 내용 

- 기존 : 리사이클러뷰의 nofityDataSetChanged 또는 notifyItemInserted를 통해 감상문을 업데이트

- 변경 : Difftutil을 통해 변경 내용을 업데이트

```
class ReportDiffCallback(
    private val oldList: List<ReportItem>,
    private val newList: List<ReportItem>,
) : DiffUtil.Callback() {
    override fun getOldListSize(): Int = oldList.size

    override fun getNewListSize(): Int = newList.size

    override fun areItemsTheSame(
        oldItemPosition: Int,
        newItemPosition: Int,
    ): Boolean {
        return oldList[oldItemPosition].reportId == newList[newItemPosition].reportId
    }

    override fun areContentsTheSame(
        oldItemPosition: Int,
        newItemPosition: Int,
    ): Boolean {
        return oldList[oldItemPosition] == newList[newItemPosition]
    }
}

```

- Recyclerview Adapter에서 사용
```

    fun setReportInfo(
        newReportList: List<ReportItem>,
    ) {
        val diffCallback = ReportDiffCallback(reportList, newReportList)
        val diffResult = DiffUtil.calculateDiff(diffCallback)
        reportList.clear()
        reportList.addAll(newReportList)
        diffResult.dispatchUpdatesTo(this)
    }
```

### 적용 이유 
기존에는 리사이클러뷰의 notifyDataSetChanged 또는 전부 업데이트를 막기 위해  notifyItemInserted를 이용하는 것이 최선이었는데 Paging 라이브러리를 통해 Diffutil을 사용해보며 이번에 감상문 로직에도 적용해보게 되었다.

무한 스크롤은 데이터 리스트에서 빈번하게 등장할 기능인데 그때마다 수동으로 구현한다면 에러가 발생할 수도 있고, 복잡도나 시간 상에서도 라이브러리를 사용하는 것이 더 효율적이라고 생각하여 이번 기회에 적용해보게 되었다.