### PR TITLE
refactor: 팔로우 로직 수정

### DIFF
--- a/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/model/follow/check/CheckIsFollowResponse.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/model/follow/check/CheckIsFollowResponse.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class CheckIsFollowResponse(
-    val isFollowing: Boolean,
-//    val followId : String
+    val isFollowing: Boolean = false,
+    val followId: String = "",
 )

--- a/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/service/FollowService.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/service/FollowService.kt
@@ -2,6 +2,7 @@ package com.teamfilmo.filmo.data.remote.service
 
 import com.teamfilmo.filmo.data.remote.model.follow.FollowerListResponse
 import com.teamfilmo.filmo.data.remote.model.follow.FollowingListResponse
+import com.teamfilmo.filmo.data.remote.model.follow.check.CheckIsFollowResponse
 import com.teamfilmo.filmo.data.remote.model.follow.count.FollowCountResponse
 import com.teamfilmo.filmo.data.remote.model.follow.save.SaveFollowResponse
 import retrofit2.http.DELETE
@@ -41,7 +42,7 @@ interface FollowService {
          * 상대 아이디
          */
         @Query("targetId") targetId: String,
-    ): Result<Boolean>
+    ): Result<CheckIsFollowResponse>
 
     /**
      * 팔로잉/차단 목록
@@ -89,6 +90,6 @@ interface FollowService {
         /**
          * 확인할 유저의 아이디
          */
-        @Query("otherUserId") userId: String?,
+        @Query("userId") userId: String?,
     ): Result<FollowCountResponse>
 }

--- a/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/source/FollowDataSourceImpl.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/source/FollowDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.teamfilmo.filmo.data.remote.source
 
 import com.teamfilmo.filmo.data.remote.model.follow.FollowerListResponse
 import com.teamfilmo.filmo.data.remote.model.follow.FollowingListResponse
+import com.teamfilmo.filmo.data.remote.model.follow.check.CheckIsFollowResponse
 import com.teamfilmo.filmo.data.remote.model.follow.count.FollowCountResponse
 import com.teamfilmo.filmo.data.remote.model.follow.save.SaveFollowResponse
 import com.teamfilmo.filmo.data.remote.service.FollowService
@@ -25,7 +26,7 @@ class FollowDataSourceImpl
             keyword: String?,
         ): Result<FollowerListResponse> = followService.getFollowerList(userId, lastUserId, keyword)
 
-        override suspend fun checkIsFollow(targetId: String): Result<Boolean> = followService.isFollow(targetId)
+        override suspend fun checkIsFollow(targetId: String): Result<CheckIsFollowResponse> = followService.isFollow(targetId)
 
         override suspend fun cancelFollow(followId: String): Result<Unit> = followService.cancelFollow(followId)
 

--- a/app/src/main/kotlin/com/teamfilmo/filmo/data/repository/FollowRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/data/repository/FollowRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.teamfilmo.filmo.data.repository
 
 import com.teamfilmo.filmo.data.remote.model.follow.FollowerListResponse
 import com.teamfilmo.filmo.data.remote.model.follow.FollowingListResponse
+import com.teamfilmo.filmo.data.remote.model.follow.check.CheckIsFollowResponse
 import com.teamfilmo.filmo.data.remote.model.follow.count.FollowCountResponse
 import com.teamfilmo.filmo.data.remote.model.follow.save.SaveFollowResponse
 import com.teamfilmo.filmo.data.source.FollowDataSource
@@ -25,7 +26,7 @@ class FollowRepositoryImpl
             keyword: String?,
         ): Result<FollowingListResponse> = followDataSource.getFollowingList(userId, lastUserId, keyword)
 
-        override suspend fun checkIsFollow(targetId: String): Result<Boolean> = followDataSource.checkIsFollow(targetId)
+        override suspend fun checkIsFollow(targetId: String): Result<CheckIsFollowResponse> = followDataSource.checkIsFollow(targetId)
 
         override suspend fun cancelFollow(followId: String): Result<Unit> = followDataSource.cancelFollow(followId)
 

--- a/app/src/main/kotlin/com/teamfilmo/filmo/data/source/FollowDataSource.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/data/source/FollowDataSource.kt
@@ -2,6 +2,7 @@ package com.teamfilmo.filmo.data.source
 
 import com.teamfilmo.filmo.data.remote.model.follow.FollowerListResponse
 import com.teamfilmo.filmo.data.remote.model.follow.FollowingListResponse
+import com.teamfilmo.filmo.data.remote.model.follow.check.CheckIsFollowResponse
 import com.teamfilmo.filmo.data.remote.model.follow.count.FollowCountResponse
 import com.teamfilmo.filmo.data.remote.model.follow.save.SaveFollowResponse
 
@@ -20,7 +21,7 @@ interface FollowDataSource {
 
     suspend fun checkIsFollow(
         targetId: String,
-    ): Result<Boolean>
+    ): Result<CheckIsFollowResponse>
 
     suspend fun cancelFollow(
         followId: String,

--- a/app/src/main/kotlin/com/teamfilmo/filmo/domain/follow/CheckIsFollowUseCase.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/domain/follow/CheckIsFollowUseCase.kt
@@ -1,5 +1,6 @@
 package com.teamfilmo.filmo.domain.follow
 
+import com.teamfilmo.filmo.data.remote.model.follow.check.CheckIsFollowResponse
 import com.teamfilmo.filmo.domain.repository.FollowRepository
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
@@ -12,7 +13,7 @@ class CheckIsFollowUseCase
     constructor(
         private val followRepository: FollowRepository,
     ) {
-        operator fun invoke(targetId: String): Flow<Boolean?> =
+        operator fun invoke(targetId: String): Flow<CheckIsFollowResponse?> =
             flow {
                 val result = followRepository.checkIsFollow(targetId)
                 result.onFailure {

--- a/app/src/main/kotlin/com/teamfilmo/filmo/domain/repository/FollowRepository.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/domain/repository/FollowRepository.kt
@@ -2,6 +2,7 @@ package com.teamfilmo.filmo.domain.repository
 
 import com.teamfilmo.filmo.data.remote.model.follow.FollowerListResponse
 import com.teamfilmo.filmo.data.remote.model.follow.FollowingListResponse
+import com.teamfilmo.filmo.data.remote.model.follow.check.CheckIsFollowResponse
 import com.teamfilmo.filmo.data.remote.model.follow.count.FollowCountResponse
 import com.teamfilmo.filmo.data.remote.model.follow.save.SaveFollowResponse
 
@@ -20,7 +21,7 @@ interface FollowRepository {
 
     suspend fun checkIsFollow(
         targetId: String,
-    ): Result<Boolean>
+    ): Result<CheckIsFollowResponse>
 
     suspend fun cancelFollow(
         followId: String,

--- a/app/src/main/kotlin/com/teamfilmo/filmo/ui/body/BodyMovieReportFragment.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/ui/body/BodyMovieReportFragment.kt
@@ -78,6 +78,7 @@ class BodyMovieReportFragment :
                 viewModel.getReportResponse.collect {
                     viewModel.handleEvent(BodyMovieReportEvent.ShowMovieInfo(it.movieId))
                     binding.apply {
+                        txtUserName.text = "뚱"
                         tvMovieTitle.text = movieName
                         tvReportTitle.text = it.title
                         reportListView.text = it.content
@@ -85,6 +86,26 @@ class BodyMovieReportFragment :
                         tvReplyCount.text = if (it.replyCount > 100) "100+" else it.replyCount.toString()
                     }
                     getImage(it.imageUrl.toString(), binding.movieImage)
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.checkIsFollowResponse.collect {
+                    binding.btnUserFollow.isSelected = it.isFollowing
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.isMyPost.collect {
+                    if (it) {
+                        binding.btnUserFollow.visibility = View.GONE
+                    } else {
+                        binding.btnUserFollow.visibility = View.VISIBLE
+                    }
                 }
             }
         }

--- a/app/src/main/res/layout/fragment_body_movie_report.xml
+++ b/app/src/main/res/layout/fragment_body_movie_report.xml
@@ -122,32 +122,34 @@
 
         <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/image_user"
-            android:layout_width="50dp"
-            android:layout_height="50dp"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
             android:layout_marginStart="20dp"
             android:layout_marginTop="4dp"
+            android:layout_marginBottom="10dp"
             android:src="@drawable/ic_duck"
+            app:layout_constraintBottom_toTopOf="@id/movie_detail"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/imageButton"
+            app:layout_constraintVertical_bias="0.019"
             app:shapeAppearance="@style/Circle50" />
 
         <TextView
             android:id="@+id/txt_user_name"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
+            android:layout_marginStart="10dp"
             android:text="뿔테안경이동진의감상문임"
             app:layout_constraintBottom_toBottomOf="@+id/image_user"
             app:layout_constraintStart_toEndOf="@+id/image_user"
-            app:layout_constraintTop_toTopOf="@+id/image_user"
-            app:layout_constraintVertical_bias="0.448" />
+            app:layout_constraintTop_toTopOf="@+id/image_user" />
 
 
         <ImageButton
             android:id="@+id/btn_user_follow"
-            android:layout_width="55dp"
+            android:layout_width="60dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
+            android:layout_marginStart="10dp"
             android:background="@drawable/btn_following"
             app:layout_constraintBottom_toBottomOf="@+id/txt_user_name"
             app:layout_constraintStart_toEndOf="@+id/txt_user_name"
@@ -157,19 +159,18 @@
             android:id="@+id/btn_meat_ball"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="20dp"
+            android:layout_marginEnd="20dp"
             android:background="@drawable/ic_more"
             app:layout_constraintBottom_toBottomOf="@+id/btn_user_follow"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/btn_user_follow"
-            app:layout_constraintTop_toTopOf="@+id/btn_user_follow" />
+            app:layout_constraintTop_toTopOf="@+id/txt_user_name" />
 
         <include
             android:id="@+id/movie_detail"
             layout="@layout/fragment_movie_detail"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@id/btn_user_follow"
+            app:layout_constraintTop_toBottomOf="@id/txt_user_name"
             android:layout_marginTop="10dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/layout/fragment_user_page.xml
+++ b/app/src/main/res/layout/fragment_user_page.xml
@@ -84,7 +84,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="10dp"
-        android:text="팔로우"
+        android:text="팔로워"
         app:layout_constraintBottom_toBottomOf="@+id/textView17"
         app:layout_constraintStart_toEndOf="@+id/txt_count_following"
         app:layout_constraintTop_toTopOf="@+id/textView17" />


### PR DESCRIPTION
- 팔로우 여부 확인 시 돌아오는 응답에서 followId를 얻고 이를 사용해서 팔로우 취소 구현
    -  이제 화면을 벗어난 후 다시 돌아와도 팔로우 여부 시 followId를 얻을 수 있으므로 팔로우 취소 가능
  
- 팔로우 수 관련 인터페이스 수정
    - 쿼리 명 (기존 - otherUserId -> userId로 변경

![body1](https://github.com/user-attachments/assets/e1d439f6-8c2a-4b25-9934-fbca926e796d)
![body2](https://github.com/user-attachments/assets/1efd757d-f6b7-4710-837d-72327db6bf2d)

### 결과
- 본문 화면에서 팔로우 등록 가능
- 본문 화면에서 팔로우 취소 가능
- 본문 화면에서 팔로우 등록 후 다른 화면을 갔다가 다시 돌아와서 팔로우 취소 가능
- 본문 화면에서 팔로우 등록 또는 취소 후 사용자 페이지로 이동할 경우 팔로우 상태 반영 가능