### PR TITLE
feat: 감상문 , 댓글 차단 구현

### DIFF
--- a/app/src/main/kotlin/com/teamfilmo/filmo/data/di/RepositoryModule.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/data/di/RepositoryModule.kt
@@ -2,6 +2,7 @@ package com.teamfilmo.filmo.data.di
 
 import com.teamfilmo.filmo.data.remote.source.ReportRepositoryImpl
 import com.teamfilmo.filmo.data.repository.AuthRepositoryImpl
+import com.teamfilmo.filmo.data.repository.BlockRepositoryImpl
 import com.teamfilmo.filmo.data.repository.BookmarkRepositoryImpl
 import com.teamfilmo.filmo.data.repository.ComplaintRepositoryImpl
 import com.teamfilmo.filmo.data.repository.FollowRepositoryImpl
@@ -11,6 +12,7 @@ import com.teamfilmo.filmo.data.repository.MovieRepositoryImpl
 import com.teamfilmo.filmo.data.repository.ReplyRepositoryImpl
 import com.teamfilmo.filmo.data.repository.UserRepositoryImpl
 import com.teamfilmo.filmo.domain.repository.AuthRepository
+import com.teamfilmo.filmo.domain.repository.BlockRepository
 import com.teamfilmo.filmo.domain.repository.BookmarkRepository
 import com.teamfilmo.filmo.domain.repository.ComplaintRepository
 import com.teamfilmo.filmo.domain.repository.FollowRepository
@@ -77,4 +79,9 @@ abstract class RepositoryModule {
     abstract fun bindComplaintRepository(
         complaintRepository: ComplaintRepositoryImpl,
     ): ComplaintRepository
+
+    @Binds
+    abstract fun bindBlockRepository(
+        blockRepository: BlockRepositoryImpl,
+    ): BlockRepository
 }

--- a/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/di/RemoteSourceModule.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/di/RemoteSourceModule.kt
@@ -1,6 +1,7 @@
 package com.teamfilmo.filmo.data.remote.di
 
 import com.teamfilmo.filmo.data.remote.source.AuthRemoteDataSourceImpl
+import com.teamfilmo.filmo.data.remote.source.BlockDataSourceImpl
 import com.teamfilmo.filmo.data.remote.source.BookmarkDataSourceImpl
 import com.teamfilmo.filmo.data.remote.source.ComplaintDataSourceImpl
 import com.teamfilmo.filmo.data.remote.source.FollowDataSourceImpl
@@ -11,6 +12,7 @@ import com.teamfilmo.filmo.data.remote.source.ReplyDataSourceImpl
 import com.teamfilmo.filmo.data.remote.source.ReportDataSourceImpl
 import com.teamfilmo.filmo.data.remote.source.UserDataSourceImpl
 import com.teamfilmo.filmo.data.source.AuthRemoteDataSource
+import com.teamfilmo.filmo.data.source.BlockDataSource
 import com.teamfilmo.filmo.data.source.BookmarkDataSource
 import com.teamfilmo.filmo.data.source.ComplaintDataSource
 import com.teamfilmo.filmo.data.source.FollowDataSource
@@ -88,4 +90,10 @@ abstract class RemoteSourceModule {
     abstract fun bindComplaintDataSource(
         complaintDataSource: ComplaintDataSourceImpl,
     ): ComplaintDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindBlockDataSource(
+        blockDataSource: BlockDataSourceImpl,
+    ): BlockDataSource
 }

--- a/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/model/block/SaveBlockRequest.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/model/block/SaveBlockRequest.kt
@@ -1,0 +1,8 @@
+package com.teamfilmo.filmo.data.remote.model.block
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SaveBlockRequest(
+    val targetId: String,
+)

--- a/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/model/block/SaveBlockResponse.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/model/block/SaveBlockResponse.kt
@@ -1,0 +1,12 @@
+package com.teamfilmo.filmo.data.remote.model.block
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SaveBlockResponse(
+    val blockId: String? = null,
+    val createDate: String? = null,
+    val lastModifiedDate: String? = null,
+    val targetId: String? = null,
+    val userId: String? = null,
+)

--- a/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/service/BlockService.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/service/BlockService.kt
@@ -1,0 +1,13 @@
+package com.teamfilmo.filmo.data.remote.service
+
+import com.teamfilmo.filmo.data.remote.model.block.SaveBlockRequest
+import com.teamfilmo.filmo.data.remote.model.block.SaveBlockResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface BlockService {
+    @POST("/block/save")
+    suspend fun saveBlock(
+        @Body saveBlockRequest: SaveBlockRequest,
+    ): Result<SaveBlockResponse>
+}

--- a/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/service/di/ServiceModule.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/service/di/ServiceModule.kt
@@ -3,6 +3,7 @@ package com.teamfilmo.filmo.data.remote.service.di
 import com.teamfilmo.filmo.data.remote.network.policy.MainApiRetrofit
 import com.teamfilmo.filmo.data.remote.network.policy.MovieApiRetrofit
 import com.teamfilmo.filmo.data.remote.service.AuthService
+import com.teamfilmo.filmo.data.remote.service.BlockService
 import com.teamfilmo.filmo.data.remote.service.BookmarkService
 import com.teamfilmo.filmo.data.remote.service.ComplaintService
 import com.teamfilmo.filmo.data.remote.service.FollowService
@@ -28,95 +29,77 @@ object ServiceModule {
     @Singleton
     fun provideAuthService(
         @MainApiRetrofit retrofit: Retrofit,
-    ): AuthService {
-        return retrofit.create(AuthService::class.java)
-    }
+    ): AuthService = retrofit.create(AuthService::class.java)
 
     @Provides
     @Singleton
     fun provideBookmarkService(
         @MainApiRetrofit retrofit: Retrofit,
-    ): BookmarkService {
-        return retrofit.create(BookmarkService::class.java)
-    }
+    ): BookmarkService = retrofit.create(BookmarkService::class.java)
 
     @Provides
     @Singleton
     fun provideComplaintService(
         @MainApiRetrofit retrofit: Retrofit,
-    ): ComplaintService {
-        return retrofit.create(ComplaintService::class.java)
-    }
+    ): ComplaintService = retrofit.create(ComplaintService::class.java)
 
     @Provides
     @Singleton
     fun provideFollowService(
         @MainApiRetrofit retrofit: Retrofit,
-    ): FollowService {
-        return retrofit.create(FollowService::class.java)
-    }
+    ): FollowService = retrofit.create(FollowService::class.java)
 
     @Provides
     @Singleton
     fun provideInquiryService(
         @MainApiRetrofit retrofit: Retrofit,
-    ): InquiryService {
-        return retrofit.create(InquiryService::class.java)
-    }
+    ): InquiryService = retrofit.create(InquiryService::class.java)
 
     @Provides
     @Singleton
     fun provideLikeService(
         @MainApiRetrofit retrofit: Retrofit,
-    ): LikeService {
-        return retrofit.create(LikeService::class.java)
-    }
+    ): LikeService = retrofit.create(LikeService::class.java)
 
     @Provides
     @Singleton
     fun provideMovieService(
         @MainApiRetrofit retrofit: Retrofit,
-    ): MovieService {
-        return retrofit.create(MovieService::class.java)
-    }
+    ): MovieService = retrofit.create(MovieService::class.java)
 
     @Provides
     @Singleton
     fun provideNotificationService(
         @MainApiRetrofit retrofit: Retrofit,
-    ): NotificationService {
-        return retrofit.create(NotificationService::class.java)
-    }
+    ): NotificationService = retrofit.create(NotificationService::class.java)
 
     @Provides
     @Singleton
     fun provideReplyService(
         @MainApiRetrofit retrofit: Retrofit,
-    ): ReplyService {
-        return retrofit.create(ReplyService::class.java)
-    }
+    ): ReplyService = retrofit.create(ReplyService::class.java)
 
     @Provides
     @Singleton
     fun provideReportService(
         @MainApiRetrofit retrofit: Retrofit,
-    ): ReportService {
-        return retrofit.create(ReportService::class.java)
-    }
+    ): ReportService = retrofit.create(ReportService::class.java)
 
     @Provides
     @Singleton
     fun provideUserService(
         @MainApiRetrofit retrofit: Retrofit,
-    ): UserService {
-        return retrofit.create(UserService::class.java)
-    }
+    ): UserService = retrofit.create(UserService::class.java)
 
     @Provides
     @Singleton
     fun provideMovieApiService(
         @MovieApiRetrofit retrofit: Retrofit,
-    ): MovieApiService {
-        return retrofit.create(MovieApiService::class.java)
-    }
+    ): MovieApiService = retrofit.create(MovieApiService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideBlockService(
+        @MainApiRetrofit retrofit: Retrofit,
+    ): BlockService = retrofit.create(BlockService::class.java)
 }

--- a/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/source/BlockDataSourceImpl.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/data/remote/source/BlockDataSourceImpl.kt
@@ -1,0 +1,15 @@
+package com.teamfilmo.filmo.data.remote.source
+
+import com.teamfilmo.filmo.data.remote.model.block.SaveBlockRequest
+import com.teamfilmo.filmo.data.remote.model.block.SaveBlockResponse
+import com.teamfilmo.filmo.data.remote.service.BlockService
+import com.teamfilmo.filmo.data.source.BlockDataSource
+import javax.inject.Inject
+
+class BlockDataSourceImpl
+    @Inject
+    constructor(
+        private val blockService: BlockService,
+    ) : BlockDataSource {
+        override suspend fun saveBlock(saveBlockRequest: SaveBlockRequest): Result<SaveBlockResponse> = blockService.saveBlock(saveBlockRequest)
+    }

--- a/app/src/main/kotlin/com/teamfilmo/filmo/data/repository/BlockRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/data/repository/BlockRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.teamfilmo.filmo.data.repository
+
+import com.teamfilmo.filmo.data.remote.model.block.SaveBlockRequest
+import com.teamfilmo.filmo.data.remote.model.block.SaveBlockResponse
+import com.teamfilmo.filmo.data.source.BlockDataSource
+import com.teamfilmo.filmo.domain.repository.BlockRepository
+import javax.inject.Inject
+
+class BlockRepositoryImpl
+    @Inject
+    constructor(
+        private val blockDataSource: BlockDataSource,
+    ) : BlockRepository {
+        override suspend fun saveBlock(saveBlockRequest: SaveBlockRequest): Result<SaveBlockResponse> = blockDataSource.saveBlock(saveBlockRequest)
+    }

--- a/app/src/main/kotlin/com/teamfilmo/filmo/data/source/BlockDataSource.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/data/source/BlockDataSource.kt
@@ -1,0 +1,8 @@
+package com.teamfilmo.filmo.data.source
+
+import com.teamfilmo.filmo.data.remote.model.block.SaveBlockRequest
+import com.teamfilmo.filmo.data.remote.model.block.SaveBlockResponse
+
+interface BlockDataSource {
+    suspend fun saveBlock(saveBlockRequest: SaveBlockRequest): Result<SaveBlockResponse>
+}

--- a/app/src/main/kotlin/com/teamfilmo/filmo/domain/block/SaveBlockUseCase.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/domain/block/SaveBlockUseCase.kt
@@ -1,0 +1,27 @@
+package com.teamfilmo.filmo.domain.block
+
+import com.teamfilmo.filmo.data.remote.model.block.SaveBlockRequest
+import com.teamfilmo.filmo.data.remote.model.block.SaveBlockResponse
+import com.teamfilmo.filmo.domain.repository.BlockRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
+import timber.log.Timber
+
+class SaveBlockUseCase
+    @Inject
+    constructor(
+        private val blockRepository: BlockRepository,
+    ) {
+        operator fun invoke(saveBlockRequest: SaveBlockRequest): Flow<SaveBlockResponse> =
+            flow {
+                val result = blockRepository.saveBlock(saveBlockRequest)
+                result.onFailure {
+                    throw it
+                }
+                emit(result.getOrNull()!!)
+            }.catch {
+                Timber.d("Failed to save block")
+            }
+    }

--- a/app/src/main/kotlin/com/teamfilmo/filmo/domain/repository/BlockRepository.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/domain/repository/BlockRepository.kt
@@ -1,0 +1,8 @@
+package com.teamfilmo.filmo.domain.repository
+
+import com.teamfilmo.filmo.data.remote.model.block.SaveBlockRequest
+import com.teamfilmo.filmo.data.remote.model.block.SaveBlockResponse
+
+interface BlockRepository {
+    suspend fun saveBlock(saveBlockRequest: SaveBlockRequest): Result<SaveBlockResponse>
+}

--- a/app/src/main/kotlin/com/teamfilmo/filmo/ui/body/BodyMovieReportEffect.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/ui/body/BodyMovieReportEffect.kt
@@ -3,6 +3,8 @@ package com.teamfilmo.filmo.ui.body
 import com.teamfilmo.filmo.base.effect.BaseEffect
 
 sealed interface BodyMovieReportEffect : BaseEffect {
+    data object BlockSuccess : BodyMovieReportEffect
+
     data object ComplaintSuccess : BodyMovieReportEffect
 
     data object CancelFollow : BodyMovieReportEffect

--- a/app/src/main/kotlin/com/teamfilmo/filmo/ui/body/BodyMovieReportEvent.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/ui/body/BodyMovieReportEvent.kt
@@ -4,7 +4,9 @@ import com.teamfilmo.filmo.base.event.BaseEvent
 import com.teamfilmo.filmo.data.remote.model.report.update.UpdateReportRequest
 
 sealed class BodyMovieReportEvent : BaseEvent() {
-    data object RegistComplaint : BodyMovieReportEvent()
+    data object SaveBlock : BodyMovieReportEvent()
+
+    data object SaveComplaint : BodyMovieReportEvent()
 
     data object ClickFollow : BodyMovieReportEvent()
 

--- a/app/src/main/kotlin/com/teamfilmo/filmo/ui/reply/ReplyEvent.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/ui/reply/ReplyEvent.kt
@@ -3,6 +3,10 @@ package com.teamfilmo.filmo.ui.reply
 import com.teamfilmo.filmo.base.event.BaseEvent
 
 sealed class ReplyEvent : BaseEvent() {
+    data class SaveBlock(
+        val targetId: String,
+    ) : ReplyEvent()
+
     data class SaveComplaint(
         val targetId: String,
     ) : ReplyEvent()

--- a/app/src/main/kotlin/com/teamfilmo/filmo/ui/reply/ReplyFragment.kt
+++ b/app/src/main/kotlin/com/teamfilmo/filmo/ui/reply/ReplyFragment.kt
@@ -43,9 +43,7 @@ class ReplyFragment :
 
     // 차단 다이얼로그
     fun showBlockDialog(
-        reportId: String,
         replyId: String,
-        position: Int,
     ) {
         val dialog =
             context?.let {
@@ -58,7 +56,7 @@ class ReplyFragment :
         dialog?.setItemClickListener(
             object : ItemClickListener {
                 override fun onClick() {
-                    Toast.makeText(context, "댓글을 차단했어요!", Toast.LENGTH_SHORT).show()
+                    viewModel.handleEvent(ReplyEvent.SaveBlock(replyId))
                 }
             },
         )
@@ -68,7 +66,6 @@ class ReplyFragment :
     // 신고 다이얼로그
     fun showComplaintDialog(
         replyId: String,
-        position: Int,
     ) {
         val dialog =
             context?.let {
@@ -208,18 +205,18 @@ class ReplyFragment :
                     bottomSheet.setListener(
                         object : OnButtonSelectedListener {
                             override fun onButtonSelected(text: String) {
-                                val reply = adapter.replyList[position].replyId
+                                val replyId = adapter.replyList[position].replyId
                                 when (text) {
                                     "신고" -> {
-                                        showComplaintDialog(reply, position)
+                                        showComplaintDialog(replyId)
                                         bottomSheet.dismiss()
                                     }
                                     "차단" -> {
-                                        showBlockDialog(args.reportId, reply, position)
+                                        showBlockDialog(replyId)
                                         bottomSheet.dismiss()
                                     }
                                     "삭제하기" -> {
-                                        showDeleteDialog(args.reportId, reply, position)
+                                        showDeleteDialog(args.reportId, replyId, position)
                                         bottomSheet.dismiss()
                                     }
 
@@ -281,11 +278,21 @@ class ReplyFragment :
 
         lifecycleScope.launch {
             /*
+            댓글 차단
+             */
+            launch {
+                viewModel.saveReplyBlockResponse.collect {
+                    Toast.makeText(context, "댓글을 차단했어요!", Toast.LENGTH_SHORT).show()
+                    // todo : 차단 시 UI 반영 사항은 ?
+                }
+            }
+            /*
             댓글 신고
              */
             launch {
                 viewModel.saveReplyComplaintResponse.collect {
                     Toast.makeText(context, "댓글을 신고했어요!", Toast.LENGTH_SHORT).show()
+                    // todo : 차단 시 UI 반영 사항은 ?
                 }
             }
             /*


### PR DESCRIPTION
- 추후 차단에 따라 감상문 데이터, 유저, 댓글을 고려해야함(api 구현 필요)

[댓글 차단.webm](https://github.com/user-attachments/assets/ee0e4ff7-066f-418a-947a-279a05a3b4c9)

[감상문 차단.webm](https://github.com/user-attachments/assets/b9ea2342-6920-42e2-ac31-832807c285d8)
